### PR TITLE
Added IPA preprocessing with hparam

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -4,7 +4,7 @@ import torch
 import torch.utils.data
 
 import layers
-from utils import load_wav_to_torch, load_filepaths_and_text
+from utils import load_wav_to_torch, load_filepaths_and_text, convert_to_ipa
 from text import text_to_sequence
 
 
@@ -16,6 +16,8 @@ class TextMelLoader(torch.utils.data.Dataset):
     """
     def __init__(self, audiopaths_and_text, hparams):
         self.audiopaths_and_text = load_filepaths_and_text(audiopaths_and_text)
+        if hparams.ipa_preprocessing:
+            convert_to_ipa(self.audiopaths_and_text)
         self.text_cleaners = hparams.text_cleaners
         self.max_wav_value = hparams.max_wav_value
         self.sampling_rate = hparams.sampling_rate

--- a/hparams.py
+++ b/hparams.py
@@ -28,7 +28,7 @@ def create_hparams(hparams_string=None, verbose=False):
         training_files='filelists/ljs_audio_text_train_filelist.txt',
         validation_files='filelists/ljs_audio_text_val_filelist.txt',
         text_cleaners=['english_cleaners'],
-        ipa_preprocessing=False
+        ipa_preprocessing=False,
 
         ################################
         # Audio Parameters             #

--- a/hparams.py
+++ b/hparams.py
@@ -28,6 +28,7 @@ def create_hparams(hparams_string=None, verbose=False):
         training_files='filelists/ljs_audio_text_train_filelist.txt',
         validation_files='filelists/ljs_audio_text_val_filelist.txt',
         text_cleaners=['english_cleaners'],
+        ipa_preprocessing=False
 
         ################################
         # Audio Parameters             #

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ librosa==0.6.0
 scipy==1.0.0
 Unidecode==1.0.22
 pillow
+eng_to_ipa==0.0.2

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,9 @@
 import numpy as np
 from scipy.io.wavfile import read
 import torch
-
+import eng_to_ipa as ipa
+import re
+import epitran
 
 def get_mask_from_lengths(lengths):
     max_len = torch.max(lengths).item()
@@ -27,3 +29,11 @@ def to_gpu(x):
     if torch.cuda.is_available():
         x = x.cuda(non_blocking=True)
     return torch.autograd.Variable(x)
+
+def convert_to_ipa(texts):
+    epi = epitran.Epitran('eng-Latn')
+    for text_mel_pair in texts:
+        text_mel_pair[1] = ipa.convert(text_mel_pair[1])
+        foreign_words = re.findall(r"[^ ]{0,}\*", text_mel_pair[1])
+        for word in foreign_words:
+            text_mel_pair[1] = text_mel_pair[1].replace(word, epi.transliterate(word[0:len(word)-1]))


### PR DESCRIPTION
Hey i added ipa preprocessing with eng_to_ipa and using epitran whenever there is no entry for a word. I couldnt test the epitran part because im on windows and installing flite is a bit problematic, but everything else works great, gonna try it on colab now. There is a new parameter in hparams.py that is ipa_preprocessing, it enables the preprocessing. Its false by default.